### PR TITLE
Update version in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: '0.9.0'
+          version: '0.15.0'
           args: '-- --test-threads 1'
 
       - name: Upload to codecov.io


### PR DESCRIPTION
Using 0.9.0 caused the following errors in my builds:
```
Error: "Failed to compile tests! Error: failed to parse lock file at: /home/runner/work/implant/implant/Cargo.lock"
Error: The process '/usr/share/rust/.cargo/bin/cargo' failed with exit code 1
```
Updating to 0.15.0 cleaned up the issue.