### PR TITLE
Fix the broken downloading (hopefully)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.15.0'
+          target: 'x86_64-unknown-linux-gnu'
           args: '-- --test-threads 1'
 
       - name: Upload to codecov.io
@@ -52,6 +53,7 @@ See [additional recipes here](https://github.com/actions-rs/meta).
 | Name        | Required | Description                                                                                              | Type   | Default |
 | ------------| :------: | ---------------------------------------------------------------------------------------------------------| ------ | --------|
 | `version`   |          | The version of `cargo-tarpaulin` that will be installed.                                                 | string | latest  |
+| `target`    |     ✓    | The target to install tarpaulin for i.e. `x86_64-unknown-linux-gnu`.                                     | string | latest  |
 | `run-types` |          | The type of tests to run (`Tests`, or `Doctests`). Runs all by default. May be overridden by `args`.     | string |         |
 | `timeout`   |          | The timeout, in seconds, before cancelling execution of a long running test. May be overriden by `args`. | string |         |
 | `args`      |          | Extra command line arguments that are passed to `cargo-tarpaulin`.                                       | string |         |

--- a/action.yml
+++ b/action.yml
@@ -6,12 +6,17 @@ branding:
   color: black
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 
 inputs:
   version:
     description: 'The version of cargo-tarpaulin to install'
+    required: true
+    default: 'latest'
+  
+  target:
+    description: 'The target to install for cargo-tarpaulin'
     required: true
     default: 'latest'
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -3,6 +3,7 @@ import { OutputType } from './config';
 
 export interface ActionInputs {
     requestedVersion: string,
+    target: String,
     timeout: string,
     runType: string,
     opts: string | null,
@@ -11,6 +12,7 @@ export interface ActionInputs {
 
 export default function getActionInputs(): ActionInputs {
     const requestedVersion = input.getInput('version');
+    const target = input.getInput('target');
     const runType = input.getInput('run-types');
     const timeout = input.getInput('timeout');
     const opts = input.getInput('args');
@@ -18,6 +20,7 @@ export default function getActionInputs(): ActionInputs {
 
     return {
         requestedVersion,
+        target,
         runType,
         timeout,
         opts,


### PR DESCRIPTION
Since tarpaulin now has release artefacts for mac (which appear first in the list when I queried) and the github API is returning tar.gz content type as `application/x-gtar` this action has been broken for some time. This PR attempts to fix it - however I don't do typescript and haven't figured out a way to test it yet.

As an aside a number of people have been contacting me directly about this action being broken, and not being a contributor to this repo I'm not able push out  a fix myself - merely recommend alternatives. I'd appreciate it if I could be added as a contributor - or if the project is deprecated if that could be made clear (i.e. big bold text in the readme and archive the project).